### PR TITLE
chore: Adjust dependencies for React Router

### DIFF
--- a/frontend/probloom/package.json
+++ b/frontend/probloom/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^4.0.8",
     "eslint-plugin-testing-library": "^4.12.4",
-    "history": "^5.0.1",
+    "history": "^4.10.1",
     "prettier": "^2.4.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/frontend/probloom/src/components/NotFound/NotFound.test.tsx
+++ b/frontend/probloom/src/components/NotFound/NotFound.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Switch } from 'react-router';
+import { NotFound } from './NotFound';
+
+describe('<NotFound />', () => {
+  it('displays title', () => {
+    const app = (
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>
+    );
+    render(app);
+    expect(screen.getByRole('heading')).toHaveTextContent(/not found/i);
+  });
+
+  it('displays message when given', () => {
+    const app = (
+      <MemoryRouter>
+        <NotFound message="TEST_MESSAGE" />
+      </MemoryRouter>
+    );
+    render(app);
+    expect(screen.getByText('TEST_MESSAGE')).toBeDefined();
+  });
+
+  it('goes back when "Go back" button is clicked', async () => {
+    const app = (
+      <MemoryRouter initialEntries={['/', '/unused']} initialIndex={1}>
+        <Switch>
+          <Route exact path="/" render={() => <div>TEST_INDEX_CONTENT</div>} />
+          <Route component={NotFound} />
+        </Switch>
+      </MemoryRouter>
+    );
+    render(app);
+    expect(screen.getByRole('heading')).toHaveTextContent(/not found/i);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent(/go back/i);
+    fireEvent.click(button);
+    await screen.findByText('TEST_INDEX_CONTENT');
+  });
+});

--- a/frontend/probloom/src/components/NotFound/NotFound.tsx
+++ b/frontend/probloom/src/components/NotFound/NotFound.tsx
@@ -1,0 +1,23 @@
+import { RouteComponentProps, withRouter } from 'react-router';
+
+export type NotFoundProps = {
+  message?: string;
+};
+
+const NotFound_ = (props: NotFoundProps & RouteComponentProps) => {
+  const message = props.message ?? 'We could not find the requested page.';
+  const goBackHandler = () => {
+    props.history.goBack();
+  };
+  return (
+    <div>
+      <h1>Not Found</h1>
+      <p>{message}</p>
+      <p>
+        <button onClick={goBackHandler}>Go back</button>
+      </p>
+    </div>
+  );
+};
+
+export const NotFound = withRouter(NotFound_);

--- a/frontend/probloom/yarn.lock
+++ b/frontend/probloom/yarn.lock
@@ -1091,7 +1091,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.7.6", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.9.2":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
   integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
@@ -5909,7 +5909,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-history@^4.9.0:
+history@^4.10.1, history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
   integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
@@ -5920,13 +5920,6 @@ history@^4.9.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
-
-history@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.0.1.tgz#de35025ed08bce0db62364b47ebbf9d97b5eb06a"
-  integrity sha512-5qC/tFUKfVci5kzgRxZxN5Mf1CV8NmJx9ByaPX0YTLx5Vz3Svh7NYp6eA4CpDq4iA9D0C1t8BNIfvQIrUI3mVw==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Note that I have suffered from version mismatch of `history` and `react-router` (and thus `connected-react-router`) when doing HW3. I should prevent that from happening this time.