### PR TITLE
Update: Problem set search test modified

### DIFF
--- a/frontend/probloom/src/containers/ProblemSet/ProblemSetSearch/ProblemSetSearch.test.tsx
+++ b/frontend/probloom/src/containers/ProblemSet/ProblemSetSearch/ProblemSetSearch.test.tsx
@@ -31,7 +31,7 @@ const ProblemSetStateTest: ProblemSetState = {
       title: 'title1',
       created_time: '2021-01-01',
       is_open: false,
-      tag: 'math',
+      tag: 'tag-mathematics',
       difficulty: 1,
       content: 'content1',
       userID: 1,
@@ -44,7 +44,7 @@ const ProblemSetStateTest: ProblemSetState = {
       title: 'title2',
       created_time: '2021-02-02',
       is_open: true,
-      tag: 'math',
+      tag: 'tag-mathematics',
       difficulty: 2,
       content: 'content2',
       userID: 2,
@@ -57,7 +57,7 @@ const ProblemSetStateTest: ProblemSetState = {
       title: 'title12',
       created_time: '1000-01-01',
       is_open: true,
-      tag: 'history',
+      tag: 'tag-physics',
       difficulty: 3,
       content: 'content3',
       userID: 12,
@@ -68,6 +68,7 @@ const ProblemSetStateTest: ProblemSetState = {
   ],
   solvers: [],
   selectedProblemSet: null,
+  selectedProblems: [],
 };
 
 const mockStore = getMockStore(UserStateTest, ProblemSetStateTest);
@@ -102,7 +103,7 @@ describe('<ProblemSetSearch />', () => {
     expect(wrapper.length).toBe(1);
     expect(spyGet).toBeCalledTimes(1);
     const wrapper2 = component.find('.ProblemSetSearchResult');
-    expect(wrapper2.length).toBe(3);
+    expect(wrapper2.length).toBe(6);
   });
 
   it('should move to ProblemSetCreate', () => {
@@ -111,7 +112,7 @@ describe('<ProblemSetSearch />', () => {
       .mockImplementation((path) => {});
     const component = mount(problemSetSearch);
     const wrapper = component.find('#create');
-    wrapper.simulate('click');
+    wrapper.at(0).simulate('click');
     expect(spyHistoryPush).toHaveBeenCalledWith('/problem/create/');
   });
 
@@ -120,72 +121,110 @@ describe('<ProblemSetSearch />', () => {
       .spyOn(history, 'push')
       .mockImplementation((path) => {});
     const component = mount(problemSetSearch);
-    const wrapper = component.find('#detail').first();
-    wrapper.simulate('click');
+    const wrapper = component.find('#detail');
+    wrapper.at(0).simulate('click');
     expect(spyHistoryPush).toHaveBeenCalledWith('/problem/2/detail/');
   });
 
   it('should search by title appropriately', () => {
     const component = mount(problemSetSearch);
-    const wrapper1 = component.find('#search_bar');
-    wrapper1.simulate('change', { target: { value: '1' } });
-    const wrapper2 = component.find('#term');
-    wrapper2.simulate('change', { target: { value: 'title' } });
+    const wrapper1 = component.find('input');
+    wrapper1.at(0).simulate('change', { target: { value: '1' } });
+    const wrapper2 = component.find({"label": "Range"});
+    const wrapper2_ = wrapper2.find("DropdownItem")
+    wrapper2_.at(1).simulate('click');
     const wrapper3 = component.find('#search');
-    wrapper3.simulate('click');
+    wrapper3.at(0).simulate('click');
     const wrapper4 = component.find('.ProblemSetSearchResult');
-    expect(wrapper4.length).toBe(2);
+    expect(wrapper4.length).toBe(4);
   });
 
   it('should search by content appropriately', () => {
     const component = mount(problemSetSearch);
-    const wrapper1 = component.find('#search_bar');
-    wrapper1.simulate('change', { target: { value: '1' } });
-    const wrapper2 = component.find('#term');
-    wrapper2.simulate('change', { target: { value: 'content' } });
+    const wrapper1 = component.find('input');
+    wrapper1.at(0).simulate('change', { target: { value: '1' } });
+    const wrapper2 = component.find({"label": "Range"});
+    const wrapper2_ = wrapper2.find("DropdownItem")
+    wrapper2_.at(2).simulate('click');
     const wrapper3 = component.find('#search');
-    wrapper3.simulate('click');
-    const wrapper4 = component.find('.ProblemSetSearchResult');
-    expect(wrapper4.length).toBe(1);
-  });
-
-  it('should search own problems appropriately', () => {
-    const component = mount(problemSetSearch);
-    const wrapper1 = component.find('#search_bar');
-    wrapper1.simulate('change', { target: { value: '1' } });
-    const wrapper2 = component.find('#creator');
-    wrapper2.simulate('change', { target: { value: 'own' } });
-    const wrapper3 = component.find('#search');
-    wrapper3.simulate('click');
-    const wrapper4 = component.find('.ProblemSetSearchResult');
-    expect(wrapper4.length).toBe(1);
-  });
-
-  it('should search by math appropriately', () => {
-    const component = mount(problemSetSearch);
-    const wrapper2 = component.find('#tag');
-    wrapper2.simulate('change', { target: { value: 'math' } });
+    wrapper3.at(1).simulate('click');
     const wrapper4 = component.find('.ProblemSetSearchResult');
     expect(wrapper4.length).toBe(2);
   });
 
+  it('should search own problems appropriately', () => {
+    const component = mount(problemSetSearch);
+    const wrapper1 = component.find('input');
+    wrapper1.at(0).simulate('change', { target: { value: '1' } });
+    const wrapper2 = component.find({"label": "Creator"});
+    const wrapper2_ = wrapper2.find("DropdownItem")
+    wrapper2_.at(1).simulate('click');
+    const wrapper3 = component.find('#search');
+    wrapper3.at(0).simulate('click');
+    const wrapper4 = component.find('.ProblemSetSearchResult');
+    expect(wrapper4.length).toBe(2);
+  });
+
+  it('should search by math appropriately', () => {
+    const component = mount(problemSetSearch);
+    const wrapper2 = component.find({"label": "Tag"});
+    const wrapper2_ = wrapper2.find("DropdownItem")
+    wrapper2_.at(5).simulate('click');
+    const wrapper4 = component.find('.ProblemSetSearchResult');
+    expect(wrapper4.length).toBe(4);
+  });
+
   it('should sort by solved appropriately', () => {
     const component = mount(problemSetSearch);
-    const wrapper1 = component.find('#sort');
-    wrapper1.simulate('change', { target: { value: 'solved' } });
+    const wrapper1 = component.find({"label": "Sort By"});
+    const wrapper1_ = wrapper1.find("DropdownItem")
+    wrapper1_.at(1).simulate('click');
     const wrapper2 = component.find('#detail');
     expect(wrapper2.at(0).text()).toBe('title12');
-    expect(wrapper2.at(1).text()).toBe('title1');
-    expect(wrapper2.at(2).text()).toBe('title2');
+    expect(wrapper2.at(2).text()).toBe('title1');
+    expect(wrapper2.at(4).text()).toBe('title2');
   });
 
   it('should sort by recommended appropriately', () => {
     const component = mount(problemSetSearch);
-    const wrapper1 = component.find('#sort');
-    wrapper1.simulate('change', { target: { value: 'recommended' } });
+    const wrapper1 = component.find({"label": "Sort By"});
+    const wrapper1_ = wrapper1.find("DropdownItem")
+    wrapper1_.at(2).simulate('click');
     const wrapper2 = component.find('#detail');
     expect(wrapper2.at(0).text()).toBe('title2');
-    expect(wrapper2.at(1).text()).toBe('title12');
-    expect(wrapper2.at(2).text()).toBe('title1');
+    expect(wrapper2.at(2).text()).toBe('title12');
+    expect(wrapper2.at(4).text()).toBe('title1');
+  });
+
+
+  it('should redirect to signin if not logged in', () => {
+    const component = mount(      
+      <Provider store={getMockStore()}>
+        <ConnectedRouter history={history}>
+          <Route path="/" exact component={ProblemSetSearch} />
+        </ConnectedRouter>
+      </Provider>
+    );
+    const wrapper = component.find("Redirect");
+    expect(wrapper.length).toBe(1);
+  });
+
+  it('should render with no problem sets', () => {
+    const NoProblemSetStateTest: ProblemSetState = {
+      problemSets: [],
+      solvers: [],
+      selectedProblemSet: null,
+      selectedProblems: [],
+    };
+    const component = mount(      
+      <Provider store={getMockStore(UserStateTest, NoProblemSetStateTest)}>
+        <ConnectedRouter history={history}>
+          <Route path="/" exact component={ProblemSetSearch} />
+        </ConnectedRouter>
+      </Provider>
+    );
+    const wrapper = component.find("Segment");
+    const wrapper2 = wrapper.find("Header")
+    expect(wrapper2.at(0).text()).toBe("No Results");
   });
 });

--- a/frontend/probloom/src/containers/ProblemSet/ProblemSetSearch/ProblemSetSearch.tsx
+++ b/frontend/probloom/src/containers/ProblemSet/ProblemSetSearch/ProblemSetSearch.tsx
@@ -91,8 +91,8 @@ class ProblemSetSearch extends Component<
   };
 
   render() {
-    if (this.props.user === null) {
-      return <Redirect to="/signin" />;
+    if (!this.props.user) {
+      return <Redirect to="/" />;
     }
 
     let problems = this.props.problemSets


### PR DESCRIPTION
Because we applied Semantic UI, I modified some part of test codes for problem set search page.
I also made one more trivial change in problem set search page that user is redirected to "/", not "/signin/", when he or she is not logged in.