### PR TITLE
Use Semantic UI for user profile summary

### DIFF
--- a/frontend/probloom/src/containers/AppHeader/AppHeader.tsx
+++ b/frontend/probloom/src/containers/AppHeader/AppHeader.tsx
@@ -19,8 +19,8 @@ const ProfileDropdown = ({ user, onSignOut }: ProfileDropdownProps) => {
     <Menu.Menu position="right">
       <Dropdown pointing item text={user.username}>
         <Dropdown.Menu>
-          <Dropdown.Item>
-            <NavLink to={`/user/${user.id}/summary`}>View Profile</NavLink>
+          <Dropdown.Item as={NavLink} to={`/user/${user.id}/summary`}>
+            View Profile
           </Dropdown.Item>
           <Dropdown.Item onClick={async () => onSignOut(user)}>
             Sign Out

--- a/frontend/probloom/src/containers/Profile/Profile.tsx
+++ b/frontend/probloom/src/containers/Profile/Profile.tsx
@@ -4,7 +4,7 @@ import './Profile.css';
 import NotFound from '../../components/NotFound/NotFound';
 import ProfileSummary from './ProfileSummary';
 import ProfileStatistics from './ProfileStatistics';
-import { Container, Tab, TabProps } from 'semantic-ui-react';
+import { Button, Container, Header, Tab, TabProps } from 'semantic-ui-react';
 import { Component } from 'react';
 import { RootState } from '../../store/store';
 import { connect, ConnectedProps } from 'react-redux';
@@ -60,16 +60,20 @@ class Profile extends Component<
 
     return (
       <Container text>
-        <h2>{this.props.selectedUser?.username}</h2>
-        <h3>{this.props.selectedUser?.email}</h3>
+        <Header as="h2">
+          {this.props.selectedUser?.username}
+          <Header.Subheader>
+            {this.props.selectedUser?.email}
+          </Header.Subheader>
+        </Header>
         <Tab
           panes={panes}
           activeIndex={activeIndex}
           onTabChange={this.handleTabChange}
         />
-        <button onClick={() => this.onClickBackButton()}>
+        <Button onClick={() => this.onClickBackButton()}>
           Back to problem search
-        </button>
+        </Button>
       </Container>
     );
   }

--- a/frontend/probloom/src/containers/Profile/ProfileSummary.css
+++ b/frontend/probloom/src/containers/Profile/ProfileSummary.css
@@ -1,0 +1,3 @@
+.profile-summary__introduction {
+  padding: 2rem;
+}

--- a/frontend/probloom/src/containers/Profile/ProfileSummary.tsx
+++ b/frontend/probloom/src/containers/Profile/ProfileSummary.tsx
@@ -1,7 +1,11 @@
 import { Component } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
+import { Button, Container, Form, Header, Icon, Segment } from 'semantic-ui-react';
+
 import { getUserProfile, updateUserIntroduction } from '../../store/actions';
 import { AppDispatch, RootState } from '../../store/store';
+
+import './ProfileSummary.css';
 
 export interface ProfileSummaryProps extends PropsFromRedux {
   userId: number;
@@ -55,66 +59,78 @@ class ProfileSummary extends Component<
   }
 
   renderIntroduction(introduction: string) {
+    const modifyIntroductionButton = (
+      <Button primary onClick={() => this.onClickModifyIntroductionButton()}>
+        Edit Introduction
+      </Button>
+    )
     return (
-      <div>
+      <Segment>
         <p>{introduction}</p>
-        <button onClick={() => this.onClickModifyIntroductionButton()}>
-          Edit Introduction
-        </button>
-      </div>
+        {modifyIntroductionButton}
+      </Segment>
     );
   }
 
   renderIntroductionPlaceholder() {
+    const modifyIntroductionButton = (
+      <Button primary onClick={() => this.onClickModifyIntroductionButton()}>
+        Write an Introduction
+      </Button>
+    )
     return (
-      <div>
-        <p>This user does not have an introduction.</p>
-        <button onClick={() => this.onClickModifyIntroductionButton()}>
-          Write an Introduction
-        </button>
-      </div>
+      <Segment placeholder>
+        <Header icon>
+          <Icon name='user' />
+          This user does not have an introduction.
+        </Header>
+        {modifyIntroductionButton}
+      </Segment>
     );
   }
 
   renderIntroductionEditor() {
     return (
-      <form onSubmit={(event) => event.preventDefault()}>
-        <textarea
-          cols={30}
-          rows={10}
+      <Form>
+        <Form.TextArea
           placeholder="Tell us about yourself..."
           value={this.state.pendingIntroduction}
           onChange={(event) =>
             this.setState({ pendingIntroduction: event.target.value })
           }
         />
-        <button
+        <Button
+          primary
           type="submit"
           disabled={this.state.pendingIntroduction === ''}
           onClick={() => this.onClickConfirmIntroductionButton()}
         >
           Confirm
-        </button>
-        <button onClick={() => this.onClickCancelIntroductionButton()}>
+        </Button>
+        <Button onClick={() => this.onClickCancelIntroductionButton()}>
           Cancel
-        </button>
-      </form>
+        </Button>
+      </Form>
     );
   }
 
   render() {
     const introduction =
-      this.props.selectedUserProfile?.introduction ?? 'test-introduction';
+      this.props.selectedUserProfile?.introduction ?? '';
     const hasIntroduction = introduction !== '';
     if (this.state.editing) {
-      return <div>{this.renderIntroductionEditor()}</div>;
+      return (
+        <Container className="profile-summary__introduction">
+          {this.renderIntroductionEditor()}
+        </Container>
+      )
     }
     return (
-      <div>
+      <Container className="profile-summary__introduction">
         {hasIntroduction
           ? this.renderIntroduction(introduction)
           : this.renderIntroductionPlaceholder()}
-      </div>
+      </Container>
     );
   }
 }


### PR DESCRIPTION
There is one unresolved issue: "Edit Introduction" button always appears even if the user is not the author of the introduction. I think fixing this requires modifying `UserReducer`, so I am waiting until merge conflicts are resolved. After all, this is a problem only when user logs out and accesses profile page directly using address bar.